### PR TITLE
Update Puppet module dependencies 

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -7,24 +7,24 @@ forge "https://forgeapi.puppetlabs.com"
 # Install modules to manage APT repositories and enable
 # unattended-upgrades on server.
 # See https://github.com/voxpupuli/puppet-unattended_upgrades
-mod "puppetlabs-apt", "2.3.0"
-mod "puppet-unattended_upgrades", "2.0.0"
+mod "puppetlabs-apt", "2.4.0"
+mod "puppet-unattended_upgrades", "2.2.0"
 
 # Install PuppetLabs Standard Libraries (includes various useful puppet methods)
 # See: https://github.com/puppetlabs/puppetlabs-stdlib
-mod "puppetlabs-stdlib", "4.12.0"
+mod "puppetlabs-stdlib", "4.24.0"
 
 # Install Puppet Labs PostgreSQL module
 # https://github.com/puppetlabs/puppetlabs-postgresql/
-mod "puppetlabs-postgresql", "4.8.0"
+mod "puppetlabs-postgresql", "4.9.0"
 
 # Install Puppet Labs Tomcat module
 # https://github.com/puppetlabs/puppetlabs-tomcat/
-mod "puppetlabs-tomcat", "1.5.0"
+mod "puppetlabs-tomcat", "1.7.0"
 
 # Install Puppet Labs Apache http module
 # https://github.com/puppetlabs/puppetlabs-apache/
-mod "puppetlabs-apache", "1.10.0"
+mod "puppetlabs-apache", "1.11.1"
 
 # Custom Module to install DSpace
 mod "DSpace/dspace",

--- a/README.md
+++ b/README.md
@@ -49,22 +49,22 @@ Here's what it currently does:
 
 1. Setup Ubuntu unattended_upgrades (via [puppet-unattended_upgrades](https://github.com/voxpupuli/puppet-unattended_upgrades) module)
 2. Setup DSpace, including all prerequisites (via our separate [puppet-dspace](https://github.com/DSpace/puppet-dspace) module). This includes setting up all of the following:
-  * PostgreSQL database (via [puppetlabs-postgresql](https://github.com/puppetlabs/puppetlabs-postgresql/) module)
-  * Tomcat (via [puppetlabs-tomcat](https://github.com/puppetlabs/puppetlabs-tomcat/) module)
-  * Apache web server (via [puppetlabs-apache](https://github.com/puppetlabs/puppetlabs-apache/) module), communicates with Tomcat via AJP
-  * 'dspace' OS user account (which is the owner of DSpace installation)
+   * PostgreSQL database (via [puppetlabs-postgresql](https://github.com/puppetlabs/puppetlabs-postgresql/) module)
+   * Tomcat (via [puppetlabs-tomcat](https://github.com/puppetlabs/puppetlabs-tomcat/) module)
+   * Apache web server (via [puppetlabs-apache](https://github.com/puppetlabs/puppetlabs-apache/) module), communicates with Tomcat via AJP
+   * 'dspace' OS user account (which is the owner of DSpace installation)
 3. Setup splash page (homepage of http://demo.dspace.org), by checking out/installing the https://github.com/DSpace/demo.dspace.org project
-  * Also includes the useful scripts / cron jobs from that project
+   * Also includes the useful scripts / cron jobs from that project
 4. 'kompewter' IRC bot (from https://github.com/DSpace-Labs/kompewter)
 5. Setup custom Message of the Day for server and other basic files
 
 **NOTE:** Currently this script downloads AIPs from a private S3 location to the `~dspace/AIP-restore` folder. If you wish to copy/clone this script for your own purposes, you can skip this step, or create your own content that looks something like this:
 
 * `~dspace/AIP-restore/`
-  * `SITE@10673-0.zip` (Site AIP corresponding to 10673/0 handle)
-  * `COMMUNITY@[handle].zip` (one or more Community AIPs using 10673 handle prefix)
-  * `COLLECTION@[handle].zip` (one or more Collection AIPs using 10673 handle prefix)
-  * `ITEM@[handle].zip` (one or more ITEM AIPs using 10673 handle prefix)
+   * `SITE@10673-0.zip` (Site AIP corresponding to 10673/0 handle)
+   * `COMMUNITY@[handle].zip` (one or more Community AIPs using 10673 handle prefix)
+   * `COLLECTION@[handle].zip` (one or more Collection AIPs using 10673 handle prefix)
+   * `ITEM@[handle].zip` (one or more ITEM AIPs using 10673 handle prefix)
 * A restore script is installed to `~/bin/reset-dspace-content` (under the 'dspace' OS user account).  At this time, it must be manually run after DSpace is installed (it is not automated).
 
 License

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ How to use it
    * Storage: Update to at least 75GB storage for ROOT
    * Launch the instance
 2. Sit back and wait while 'cloud-init' & Puppet does all the hard work for you.
-3. (Temporary) At this point in time, there's an odd bug where PostgreSQL doesn't startup correctly when Puppet is run from `cloud-init`.  So, you have to MANUALLY trigger the Puppet build.
+   * The entire process may take ~15 mins
+3. If you want to check on the status:
    * SSH to the server
-   * Run: `sudo puppet apply /etc/puppet/manifests/site.pp -v`
-   * Wait for Puppet to install DSpace, and setup the Demo server.
-
+   * `tail -f /var/log/cloud-init-output.log`
+   * Once it reports `System boot (via cloud-init) is COMPLETE`, then the server is done setting itself up.
 
 How it works
 ------------
@@ -35,8 +35,8 @@ Here's what the [`cloud-init.yaml`](https://github.com/duraspace/puppet-dspace-d
 3. Runs 'apt-get update' and 'apt-get upgrade' to ensure all is up-to-date (reboots if needed)
 4. Installs all necessary software on server (e.g. Puppet, librarian-puppet, Git)
 5. Clones this 'puppet-dspace-demo' GitHub repo to server (at `/etc/puppet/`)
-6. Runs '[librarian-puppet](http://librarian-puppet.com/)' to install any Puppet module dependencies (specified in Puppetfile)
-7. Runs `puppet apply /etc/puppet/manifests/site.pp` to finish the setup of the server
+6. Runs '[librarian-puppet](http://librarian-puppet.com/)' to install any Puppet module dependencies (specified in [Puppetfile](https://github.com/DSpace-Labs/puppet-dspace-demo/blob/master/Puppetfile))
+7. Runs `puppet apply /etc/puppet/manifests/site.pp` to actually install Postgres, Tomcat, Apache and DSpace (using the Puppet modules for each)
 
 *Note: all actions taken by 'cloud-init' are logged to `/var/log/cloud-init.log`. The output/results are logged to `/var/log/cloud-init-output.log`.*
 
@@ -58,14 +58,14 @@ Here's what it currently does:
 4. 'kompewter' IRC bot (from https://github.com/DSpace-Labs/kompewter)
 5. Setup custom Message of the Day for server and other basic files
 
-**WARNING:** Currently this script does restore APIs from the `~dspace/AIP-restore` folder. It does download the AIPs from a private S3 location, but you must manually run the restore script. The folder should look something like this:
+**NOTE:** Currently this script downloads AIPs from a private S3 location to the `~dspace/AIP-restore` folder. If you wish to copy/clone this script for your own purposes, you can skip this step, or create your own content that looks something like this:
 
 * `~dspace/AIP-restore/`
   * `SITE@10673-0.zip` (Site AIP corresponding to 10673/0 handle)
   * `COMMUNITY@[handle].zip` (one or more Community AIPs using 10673 handle prefix)
   * `COLLECTION@[handle].zip` (one or more Collection AIPs using 10673 handle prefix)
   * `ITEM@[handle].zip` (one or more ITEM AIPs using 10673 handle prefix)
-
+* A restore script is installed to `~/bin/reset-dspace-content` (under the 'dspace' OS user account).  At this time, it must be manually run after DSpace is installed (it is not automated).
 
 License
 --------

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -11,11 +11,11 @@ fqdn: "demo.dspace.org"
 
 # Tells cloud-init to manage /etc/hosts (based on /etc/cloud/templates/hosts.tmpl)
 # NOTE: This sets the configured 'hostname' into /etc/hosts
-manage_etc_hosts: True
+manage_etc_hosts: true
 
 # Add apt repositories
 apt_sources:
- # Enable "multiverse" repos (already enabled by default in our AMI)
+ # Enable "multiverse" repos (already enabled by default in the Ubuntu AMI we use)
  #- source: deb $MIRROR $RELEASE multiverse
  #- source: deb-src $MIRROR $RELEASE multiverse
  #- source: deb $MIRROR $RELEASE-updates multiverse
@@ -59,7 +59,7 @@ runcmd:
  - [sh, -c, "umask 0226; echo 'Defaults env_keep += \"SSH_AUTH_SOCK\"' > /etc/sudoers.d/ssh-auth-sock"]
  # Ensure pip is latest version
  - pip install --upgrade pip
- # Install AWS CLI
+ # Install AWS CLI tools
  - pip install awscli
  # Update rubygems to latest version
  - gem install --no-ri --no-rdoc rubygems-update
@@ -68,15 +68,13 @@ runcmd:
  - PUPPET_DIR="/etc/puppet"
  - rm -rf $PUPPET_DIR/*
  - git clone https://github.com/DSpace-Labs/puppet-dspace-demo.git $PUPPET_DIR
+ # To checkout a different git branch, uncomment below and change branch name
+ #- cd $PUPPET_DIR && git checkout master
  # Install puppet module dependencies (via librarian-puppet)
- - gem install --no-ri --no-rdoc librarian-puppet --version 2.2.3
+ - gem install --no-ri --no-rdoc librarian-puppet --version 3.0.0
  - cd $PUPPET_DIR && HOME=/root librarian-puppet install
  # Run puppet
- # NOTE: PUPPET DISABLED. MUST BE RUN MANUALLY AFTER SERVER INITIALIZES.
- # Currently, when kicked off via cloud-init, the PostgreSQL database fails to startup the first time.
- # Unclear if the problem is in puppet-postgresql, or if it's in cloud-init.
- # However, everything works perfectly when Puppet is run manually after server fully initializes.
- #- puppet apply $PUPPET_DIR/manifests/site.pp -v
+ - puppet apply $PUPPET_DIR/manifests/site.pp -v
 
 # boot commands
 # These are like 'runcmd', but run very early in the boot process & run on every boot by default.


### PR DESCRIPTION
Minor update to ensure all our third-party Puppet modules are up to date.

This updates them all to the latest versions that are compatible with Puppet v3.  

We have not yet updated to Puppet v4 (as updating to Puppet v4 requires more significant changes, including the Puppet directory structure: https://puppet.com/docs/puppet/4.10/whered_it_go.html)

Lightly tested on Ubuntu 16.04 LTS.  Will be performing more testing before merging.